### PR TITLE
Dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 MAINTAINER Matthew Horwood <matt@horwood.biz>
 
 # Install required deb packages


### PR DESCRIPTION
ALPINE LINUX 3.15.1 RELEASED
The Alpine Linux project is pleased to announce the immediate availability of version 3.15.1 of its Alpine Linux operating system.

This release includes a fix for openssl [CVE-2022-0778](https://security.alpinelinux.org/vuln/CVE-2022-0778).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mhzawadi/phpmyadmin/9)
<!-- Reviewable:end -->
