### PR TITLE
phpMyAdmin 5.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update && \
     && rm -f /var/cache/apk/*;
 
 # Calculate download URL
-ENV VERSION 5.2.0
+ENV VERSION 5.2.1
 ENV URL https://files.phpmyadmin.net/phpMyAdmin/${VERSION}/phpMyAdmin-${VERSION}-all-languages.tar.xz
 LABEL version=$VERSION
 


### PR DESCRIPTION
- issue #17506 Fix error when configuring 2FA without XMLWriter or  Imagick
- issue #17519 Fix Export pages not working in certain conditions
- issue #17121 Fix password_hash function incorrectly adding single  quotes to password before hashing
- issue #17736 Add utf8mb3 as an alias of utf8 on the charset  description page
- issue #17248 Support the UUID data type for MariaDB >= 10.7
- issue #16042 Fixes malformed downloads when using gzip compression  type and FireFox browser
- Add `spellcheck="false"` to all password fields and some text fields  to avoid spell-jacking data leaks
- Fixes for JavaScript errors when using Designer
- Fixes for PHP 8.2 compatibility